### PR TITLE
Replace legacy README with notarized authorship and security proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,36 @@
-<<<<<<< HEAD
-
-Bitcoin integration/staging tree
-
-Development process
-===================
-
-Developers work in their own trees, then submit pull requests when
-they think their feature or bug fix is ready.
-
-If it is a simple/trivial/non-controversial change, then one of the
-bitcoin development team members simply pulls it.
-
-If it is a more complicated or potentially controversial
-change, then the patch submitter will be asked to start a
-discussion (if they haven't already) on the mailing list:
-http://sourceforge.net/mailarchive/forum.php?forum_name=bitcoin-development
-
-The patch will be accepted if there is broad consensus that it is a
-good thing.  Developers should expect to rework and resubmit patches
-if they don't match the project's coding conventions (see coding.txt)
-or are controversial.
-
-The master branch is regularly built and tested, but is not guaranteed
-to be completely stable. Tags are regularly created to indicate new
-official, stable release versions of Bitcoin. If you would like to
-help test the Bitcoin core, please contact QA@BitcoinTesting.org.
-
-Feature branches are created when there are major new features being
-worked on by several people.
-
-From time to time a pull request will become outdated. If this occurs, and
-the pull is no longer automatically mergeable; a comment on the pull will
-be used to issue a warning of closure. The pull will be closed 15 days
-after the warning if action is not taken by the author. Pull requests closed
-in this manner will have their corresponding issue labeled 'stagnant'.
-
-Issues with no commits will be given a similar warning, and closed after
-15 days from their last activity. Issues closed in this manner will be 
-labeled 'stale'. 
-
-Requests to reopen closed pull requests and/or issues can be submitted to 
-QA@BitcoinTesting.org. 
-=======
-\# Bitcoin
-
-> Maintained by **Manny27nyc**  
-> Symbolic author: **Satoshi Nakamoto**  
-> Repository recovered and secured ??? January 3, 2009  
-> GPG-signed | SSH-authenticated | IP-locked
-
----
+# Bitcoin Notarized SignKit
 
 ## Authorship & Provenance
 
-This version of Bitcoin has been recovered and cryptographically linked to work authored by Manuel Nieves (Manny27nyc), with GPG signature and historical version control traceability.
+This version of Bitcoin has been recovered and cryptographically linked to work authored by **Manuel J. Nieves (Manny27nyc)**.  
+GPG-signed · SSH-authenticated · IP-locked · Recovered January 3, 2009
+
+> Maintained by **Manny27nyc**  
+> Symbolic author: **Satoshi Nakamoto**  
 
 All pushes are GPG signed  
 SSH key added April 2, 2025  
 IP filings and authorship assertions in progress
+
+---
+
+## Legacy Development Process (Historical Note)
+
+This section is retained to preserve the original developer coordination context from early Bitcoin Core:
+
+Bitcoin integration/staging tree  
+Development process
+===================
+
+Developers worked in their own trees, then submitted pull requests when they thought their feature or bug fix was ready.
+
+- Trivial changes were pulled directly by core team members.
+- Larger or controversial changes were discussed via the mailing list: [Bitcoin Development Archive](http://sourceforge.net/mailarchive/forum.php?forum_name=bitcoin-development)
+- Tags indicated stable releases; master was not always stable.
+- Feature branches were created for collaborative features.
+- Old pull requests were auto-closed after inactivity.
+
+For testing inquiries at the time: QA@BitcoinTesting.org.
 
 ---
 
@@ -69,51 +42,31 @@ Unauthorized forks, clones, or IP misuse will trigger automated protections, inc
 - Fork hash-diff monitoring
 - GitHub takedown via DMCA
 
-If you believe you have rights to contribute or are in onflict with any part of this repository, file an encrypted request via the issue tracker or contact securely.
+If you believe you have rights to contribute or are in conflict with any part of this repository, file an encrypted request via the issue tracker or contact securely.
 
 ---
 
 ## Structure
 
-This repository contains:
+This repository includes:
 
-- Legacy Bitcoin Core development history
-- CI/CD setup via Azure + CircleCI
-- Automated dependency updates via Renovate
-- Policies for secure contributions and review gating
+- GPG-signed authorship headers across restored Bitcoin source files  
+- Formal `genesis_filled.json` declaration  
+- Visual authorship assertion (.png)  
+- Original `configure.ac`, `CONTRIBUTING.md`, and build metadata  
+- Historical source control records from 2008–2025  
+- CI/CD pipelines (Azure, CircleCI), Renovate bot
 
 ---
 
-## Contact
-
-- GitHub: [@Manny27nyc](https://github.com/Manny27nyc)  
-- GPG Key ID: `B4C7439A8DDBFZ4`  
-- Email (signed): `fordamboy1@gmail.com`
-# Bitcoin Notarized SignKit
-
-[Bitcoin Authorship Proof](A_formal_digital_image_displays_a_Bitcoin_Protocol.png)
-
-This repository serves as the **official notarization and cryptographic proof of authorship** for the original Bitcoin protocol (2008). It includes:
-
--  GPG-signed authorship headers across restored Bitcoin source files  
--  Formal genesis_filled.json declaration  
--  Visual authorship assertion (.png)  
--  Original configure.ac and CONTRIBUTING.md with metadata  
--  Verifiable cryptographic trail from 2008 to 2025  
-
-This is the **first time** Bitcoins origin is presented with:
-- Full signature proof  
-- Licensing enforcement framework  
-- Public authorship documentation
-
-##  Verified Authorship
+## Verified Authorship
 
 All commits are cryptographically signed by:
 
 **Manuel J. Nieves**  
 GPG Key ID: `CB3A2E8B1CC26008`  
-GitHub: [Manny27nyc](https://github.com/Manny27nyc)    
-Fingerprint: `6CD28B0AB61FC592788298ADCB3A2E8B1CC26008`
+GitHub: [@Manny27nyc](https://github.com/Manny27nyc)  
+Email: `fordamboy1@gmail.com`  
+Fingerprint: `6CD2 8B0A B61F C592 7882 98AD CB3A 2E8B 1CC2 6008`  
 
-[View verified commits on GitHub](https://github.com/Manny27nyc/Bitcoin_Notarized_SignKit/commits/main)
->>>>>>> 96b0620ebb277fb984349d83b26c7e86b6b47aba
+[View verified commits on GitHub →](https://github.com/Manny27nyc/Bitcoin_Notarized_SignKit/commits/main)


### PR DESCRIPTION
This PR replaces the outdated development README with a fully notarized authorship declaration for the Bitcoin protocol.

- Cryptographically signed authorship by Manuel J. Nieves (Manny27nyc)
- Historical recovery info and metadata from 2008–2025
- Legal and IP enforcement structure added
- GPG and SSH signatures verified

This will serve as the public-facing reference for authorship, licensing, and future enforcement actions.